### PR TITLE
Refactor Parser by extracting helper methods

### DIFF
--- a/src/main/java/duke/commands/Parser.java
+++ b/src/main/java/duke/commands/Parser.java
@@ -26,50 +26,43 @@ public class Parser {
         String rest = (words.length > 1) ? words[1] : null;
 
         switch (keyword) {
-        case "bye":
-            return new ExitCommand();
-
-        case "list":
-            return new ListCommand();
-
-        case "todo":
-            if (rest == null || rest.trim().isEmpty()) {
-                throw new ACowException("Don't forget to add a tasty curry recipe to your todo list!");
-            }
-            return new AddCommand(new Todo(rest));
-
-        case "deadline":
-            if (rest == null) {
-                throw new ACowException("Need '/by!'");
-            }
-            String[] deadParts = rest.split(" /by ");
-            if (deadParts.length < 2) {
-                throw new ACowException("By when? Christmas?");
-            }
-            return new AddCommand(new Deadline(deadParts[0], deadParts[1]));
-
-        case "event":
-            String[] halves = rest.split(" /to ");
-            assert halves.length == 2: "Halves means split in 2";
-            String name = halves[0].split(" /from ")[0];
-            String from = halves[0].split(" /from ")[1];
-            String to = halves[1];
-            return new AddCommand(new Event(name, from, to));
-
-        case "mark":
-            return new MarkCommand(Integer.parseInt(rest));
-
-        case "unmark":
-            return new UnmarkCommand(Integer.parseInt(rest));
-
-        case "delete":
-            return new DeleteCommand(Integer.parseInt(rest));
-
-        case "find":
-            return new FindCommand(rest);
-
-        default:
-            throw new ACowException("I don't understand like when Shohib talks to me");
+        case "bye": return new ExitCommand();
+        case "list": return new ListCommand();
+        case "todo": return parseTodo(rest);
+        case "deadline": return parseDeadline(rest);
+        case "event": return parseEvent(rest);
+        case "mark": return new MarkCommand(Integer.parseInt(rest));
+        case "unmark": return new UnmarkCommand(Integer.parseInt(rest));
+        case "delete": return new DeleteCommand(Integer.parseInt(rest));
+        case "find": return new FindCommand(rest);
+        default: throw new ACowException("I don't understand like when Shohib talks to me");
         }
+    }
+
+    private static Command parseTodo(String rest) {
+        if (rest == null || rest.trim().isEmpty()) {
+            throw new ACowException("Don't forget to add a tasty curry recipe to your todo list!");
+        }
+        return new AddCommand(new Todo(rest));
+    }
+
+    private static Command parseDeadline(String rest) {
+        if (rest == null) {
+            throw new ACowException("Need '/by!'");
+        }
+        String[] deadParts = rest.split(" /by ");
+        if (deadParts.length < 2) {
+            throw new ACowException("By when? Christmas?");
+        }
+        return new AddCommand(new Deadline(deadParts[0], deadParts[1]));
+    }
+
+    private static Command parseEvent(String rest) {
+        String[] halves = rest.split(" /to ");
+        assert halves.length == 2: "Halves means split in 2";
+        String name = halves[0].split(" /from ")[0];
+        String from = halves[0].split(" /from ")[1];
+        String to = halves[1];
+        return new AddCommand(new Event(name, from, to));
     }
 }


### PR DESCRIPTION
Reduced the parse() method from ~60 LOC to ~15 LOC by splitting the logic for todo, deadline, and event commands into dedicated helper methods.

This improves code quality by:
- Lowering cyclomatic complexity of parse()
- Increasing cohesion (each helper does one thing)
- Making individual parsing logic easier to test